### PR TITLE
Fix OpenAI client init for proxies and add fallback

### DIFF
--- a/custom_components/entity_renamer/__init__.py
+++ b/custom_components/entity_renamer/__init__.py
@@ -196,9 +196,24 @@ class OpenAISuggestionsView(HomeAssistantView):
                     timeout=30.0
                 )
             except TypeError as init_error:
-                # Fallback for older versions or environment issues
-                _LOGGER.warning("OpenAI client init failed, trying alternative: %s", init_error)
-                client = openai.OpenAI(api_key=api_key)
+                # Fallbacks for older versions or environment issues
+                _LOGGER.warning(
+                    "OpenAI client init failed, trying alternative: %s",
+                    init_error,
+                )
+                try:
+                    client = openai.OpenAI(api_key=api_key)
+                except TypeError as second_error:
+                    _LOGGER.warning(
+                        "OpenAI client init failed again, using basic HTTP client: %s",
+                        second_error,
+                    )
+                    import httpx
+
+                    client = openai.OpenAI(
+                        api_key=api_key,
+                        http_client=httpx.Client(timeout=30.0),
+                    )
             
             # Prepare the prompt
             prompt = "Suggest better, more descriptive names for the following Home Assistant entities. "

--- a/custom_components/entity_renamer/config_flow.py
+++ b/custom_components/entity_renamer/config_flow.py
@@ -38,9 +38,24 @@ class EntityRenamerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             timeout=30.0
                         )
                     except TypeError as init_error:
-                        # Fallback for older versions or environment issues
-                        _LOGGER.warning("OpenAI client init failed, trying alternative: %s", init_error)
-                        client = openai.OpenAI(api_key=api_key)
+                        # Fallbacks for older versions or environment issues
+                        _LOGGER.warning(
+                            "OpenAI client init failed, trying alternative: %s",
+                            init_error,
+                        )
+                        try:
+                            client = openai.OpenAI(api_key=api_key)
+                        except TypeError as second_error:
+                            _LOGGER.warning(
+                                "OpenAI client init failed again, using basic HTTP client: %s",
+                                second_error,
+                            )
+                            import httpx
+
+                            client = openai.OpenAI(
+                                api_key=api_key,
+                                http_client=httpx.Client(timeout=30.0),
+                            )
                     
                     # Simple test call to validate the API key
                     await self.hass.async_add_executor_job(
@@ -129,9 +144,24 @@ class EntityRenamerOptionsFlow(config_entries.OptionsFlow):
                             timeout=30.0
                         )
                     except TypeError as init_error:
-                        # Fallback for older versions or environment issues
-                        _LOGGER.warning("OpenAI client init failed, trying alternative: %s", init_error)
-                        client = openai.OpenAI(api_key=api_key)
+                        # Fallbacks for older versions or environment issues
+                        _LOGGER.warning(
+                            "OpenAI client init failed, trying alternative: %s",
+                            init_error,
+                        )
+                        try:
+                            client = openai.OpenAI(api_key=api_key)
+                        except TypeError as second_error:
+                            _LOGGER.warning(
+                                "OpenAI client init failed again, using basic HTTP client: %s",
+                                second_error,
+                            )
+                            import httpx
+
+                            client = openai.OpenAI(
+                                api_key=api_key,
+                                http_client=httpx.Client(timeout=30.0),
+                            )
                     
                     # Simple test call to validate the API key
                     await self.hass.async_add_executor_job(

--- a/custom_components/entity_renamer/manifest.json
+++ b/custom_components/entity_renamer/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/gatesry/AI-entity-renamer/issues",
   "dependencies": ["http"],
   "codeowners": ["@gatesry"],
-  "requirements": ["openai>=1.0.0"],
+  "requirements": ["openai>=1.0.0", "httpx>=0.24.1"],
   "config_flow": true,
   "version": "1.0.0",
   "iot_class": "local_polling",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,4 @@ max-line-length = "100"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = "test_*.py"
+asyncio_mode = "auto"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,17 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
+import asyncio
+import pytest
 from homeassistant.core import HomeAssistant
 
 
 @pytest.fixture
-def hass(event_loop):
+def hass():
     """Return a Home Assistant instance for testing."""
-    hass = HomeAssistant(event_loop)
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    hass = HomeAssistant(loop)
     hass.config.components.add("http")
     
     # Set up mocks for HTTP
@@ -31,8 +35,9 @@ def hass(event_loop):
     hass.helpers.entity_registry = MagicMock()
     
     yield hass
-    
-    event_loop.run_until_complete(hass.async_stop())
+
+    loop.run_until_complete(hass.async_stop())
+    loop.close()
 
 
 @pytest.fixture

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,15 +1,20 @@
 """Test the config flow for AI Entity Renamer."""
 from unittest.mock import patch, MagicMock
 
+import os
+import sys
 import pytest
 from homeassistant import config_entries, setup
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import RESULT_TYPE_FORM, RESULT_TYPE_CREATE_ENTRY
+from homeassistant.data_entry_flow import FlowResultType
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from custom_components.entity_renamer.config_flow import EntityRenamerConfigFlow
 from custom_components.entity_renamer.const import DOMAIN
 
 
+@pytest.mark.asyncio
 async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
     await setup.async_setup_component(hass, "http", {})
@@ -20,7 +25,7 @@ async def test_form(hass: HomeAssistant) -> None:
     
     # Test that the form is returned
     result = await flow.async_step_user()
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     
     # Test form submission with valid data
@@ -37,13 +42,43 @@ async def test_form(hass: HomeAssistant) -> None:
             }
         )
         
-        assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["title"] == "AI Entity Renamer"
         assert result["data"] == {
             "api_key": "test_api_key",
         }
 
 
+@pytest.mark.asyncio
+async def test_form_openai_httpx_fallback(hass: HomeAssistant) -> None:
+    """Test OpenAI client fallback when initialization fails."""
+    await setup.async_setup_component(hass, "http", {})
+
+    flow = EntityRenamerConfigFlow()
+    flow.hass = hass
+
+    mock_client = MagicMock()
+    mock_client.models.list.return_value = []
+
+    with patch(
+        "custom_components.entity_renamer.config_flow.openai.OpenAI",
+        side_effect=[TypeError("proxies"), TypeError("proxies"), mock_client],
+    ) as mock_openai, patch(
+        "custom_components.entity_renamer.config_flow.httpx.Client",
+        return_value=MagicMock(),
+        create=True,
+    ) as mock_http_client, patch(
+        "homeassistant.components.http.ban.async_is_banned",
+        return_value=False,
+    ):
+        result = await flow.async_step_user({"api_key": "test_api_key"})
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert mock_openai.call_count == 3
+        mock_http_client.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_form_invalid_api_key(hass: HomeAssistant) -> None:
     """Test we handle invalid API key."""
     await setup.async_setup_component(hass, "http", {})
@@ -69,11 +104,12 @@ async def test_form_invalid_api_key(hass: HomeAssistant) -> None:
             }
         )
         
-        assert result["type"] == RESULT_TYPE_FORM
+        assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "user"
         assert result["errors"] == {"api_key": "invalid_api_key"}
 
 
+@pytest.mark.asyncio
 async def test_form_no_api_key(hass: HomeAssistant) -> None:
     """Test we handle no API key."""
     await setup.async_setup_component(hass, "http", {})
@@ -89,6 +125,6 @@ async def test_form_no_api_key(hass: HomeAssistant) -> None:
         }
     )
     
-    assert result["type"] == RESULT_TYPE_FORM
+    assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"api_key": "api_key_required"}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,11 +1,16 @@
 """Tests for AI Entity Renamer integration."""
+import os
+import sys
 import pytest
 from unittest.mock import patch, MagicMock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from homeassistant.setup import async_setup_component
 from custom_components.entity_renamer import DOMAIN
 
 
+@pytest.mark.asyncio
 async def test_setup(hass):
     """Test the setup of the integration."""
     with patch("custom_components.entity_renamer.frontend.async_register_built_in_panel"), \
@@ -17,6 +22,7 @@ async def test_setup(hass):
         assert DOMAIN in hass.data
 
 
+@pytest.mark.asyncio
 async def test_apply_rename_service(hass):
     """Test the apply_rename service."""
     from custom_components.entity_renamer import apply_rename_service


### PR DESCRIPTION
## Summary
- handle OpenAI client init when TypeError for unknown params
- require httpx dependency and test OpenAI fallback
- update test harness for newer Home Assistant and asyncio

## Testing
- `pytest` *(fails: RuntimeError: no running event loop)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0cd2133c83298cfb180b27b0d6b4