### PR TITLE
feat: add template driven entity id prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Managing entity names in Home Assistant can become tedious as your smart home gr
 - View all entities with their area, device, name, and entity ID
 - Filter and search for specific entities
 - Select multiple entities for bulk renaming
-- Get AI-powered name suggestions from OpenAI
+- Get AI-powered entity ID suggestions from OpenAI following a structured naming template
 - Apply suggested names individually or all at once
 
 The integration adds a dedicated sidebar icon for easy access and provides a clean, intuitive interface for managing your entity names.
@@ -61,7 +61,7 @@ Once installed, the integration will automatically maintain its version informat
 2. Click on it to open the AI Entity Renamer interface
 3. Browse or search for entities you want to rename
 4. Select the entities you want to rename
-5. Click "Get Name Suggestions" to receive AI-generated name suggestions
+5. Click "Get ID Suggestions" to receive AI-generated entity ID suggestions
 6. Review the suggestions and apply them individually or all at once
 
 ## Requirements

--- a/custom_components/entity_renamer/README.md
+++ b/custom_components/entity_renamer/README.md
@@ -7,7 +7,7 @@ A custom component for Home Assistant that allows you to bulk rename entities us
 - View all entities in your Home Assistant instance with their area, device, name, and entity ID
 - Filter entities by area, device, or search term
 - Select multiple entities for bulk renaming
-- Get AI-powered name suggestions from OpenAI
+- Get AI-powered entity ID suggestions from OpenAI following a structured naming template
 - Apply suggested names individually or all at once
 - Access via a dedicated sidebar icon
 
@@ -46,7 +46,7 @@ Once installed, the integration will automatically maintain its version informat
 2. Click on it to open the AI Entity Renamer interface
 3. Browse or search for entities you want to rename
 4. Select the entities you want to rename
-5. Click "Get Name Suggestions" to receive AI-generated name suggestions
+5. Click "Get ID Suggestions" to receive AI-generated entity ID suggestions
 6. Review the suggestions and apply them individually or all at once
 
 ## Services

--- a/custom_components/entity_renamer/__init__.py
+++ b/custom_components/entity_renamer/__init__.py
@@ -1,25 +1,25 @@
 """Entity Renamer integration for Home Assistant."""
+import json
 import logging
 import os
+
+import homeassistant.helpers.entity_registry as er
 import voluptuous as vol
 from homeassistant.components import frontend
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.typing import ConfigType
 from homeassistant.components.http import HomeAssistantView, StaticPathConfig
-from homeassistant.helpers.device_registry import async_get as async_get_device_registry
-import homeassistant.helpers.entity_registry as er
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.area_registry import async_get as async_get_area_registry
-import json
+from homeassistant.helpers.device_registry import async_get as async_get_device_registry
+from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, VERSION
 
 _LOGGER = logging.getLogger(__name__)
 
-CONFIG_SCHEMA = vol.Schema(
-    {DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA
-)
+CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
+
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Entity Renamer component."""
@@ -53,30 +53,35 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         DOMAIN,
         "apply_rename",
         apply_rename_service,
-        schema=vol.Schema({
-            vol.Required("entity_id"): cv.string,
-            vol.Required("new_name"): cv.string,
-        }),
+        schema=vol.Schema(
+            {
+                vol.Required("entity_id"): cv.string,
+                vol.Required("new_name"): cv.string,
+            }
+        ),
     )
 
     # Serve local files
-    await hass.http.async_register_static_paths([
-        StaticPathConfig(
-            "/entity_renamer",
-            os.path.join(os.path.dirname(__file__), "frontend"),
-            False
-        )
-    ])
+    await hass.http.async_register_static_paths(
+        [
+            StaticPathConfig(
+                "/entity_renamer", os.path.join(os.path.dirname(__file__), "frontend"), False
+            )
+        ]
+    )
 
     return True
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Entity Renamer from a config entry."""
     return True
 
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return True
+
 
 class EntityListView(HomeAssistantView):
     """View to handle Entity List requests."""
@@ -88,7 +93,7 @@ class EntityListView(HomeAssistantView):
         """Handle GET request for entity list."""
         hass = request.app["hass"]
         registry = er.async_get(hass)
-        
+
         entities = []
         for entity_id, entity in registry.entities.items():
             # Get device info if available
@@ -96,30 +101,33 @@ class EntityListView(HomeAssistantView):
             device_name = "No Device"
             area_id = None
             area_name = "No Area"
-            
+
             if device_id:
                 device_registry = async_get_device_registry(hass)
                 device = device_registry.async_get(device_id)
                 if device:
                     device_name = device.name or device.model or "Unknown Device"
                     area_id = device.area_id
-            
+
             # Get area info if available
             if area_id:
                 area_registry = async_get_area_registry(hass)
                 area = area_registry.async_get_area(area_id)
                 if area:
                     area_name = area.name
-            
-            entities.append({
-                "entity_id": entity_id,
-                "name": entity.name or entity_id.split(".")[-1],
-                "device_name": device_name,
-                "area_name": area_name,
-                "original_name": entity.original_name,
-            })
-        
+
+            entities.append(
+                {
+                    "entity_id": entity_id,
+                    "name": entity.name or entity_id.split(".")[-1],
+                    "device_name": device_name,
+                    "area_name": area_name,
+                    "original_name": entity.original_name,
+                }
+            )
+
         return self.json(entities)
+
 
 class RenameEntityView(HomeAssistantView):
     """View to handle Entity Rename requests."""
@@ -131,26 +139,23 @@ class RenameEntityView(HomeAssistantView):
         """Handle POST request for renaming entities."""
         hass = request.app["hass"]
         data = await request.json()
-        
+
         entity_id = data.get("entity_id")
         new_name = data.get("new_name")
-        
+
         if not entity_id or not new_name:
             return self.json(
-                {"success": False, "error": "Missing entity_id or new_name"}, 
-                status_code=400
+                {"success": False, "error": "Missing entity_id or new_name"}, status_code=400
             )
-        
+
         registry = er.async_get(hass)
         try:
             registry.async_update_entity(entity_id, name=new_name)
             return self.json({"success": True})
         except Exception as e:
             _LOGGER.error("Error renaming entity: %s", e)
-            return self.json(
-                {"success": False, "error": str(e)}, 
-                status_code=500
-            )
+            return self.json({"success": False, "error": str(e)}, status_code=500)
+
 
 class OpenAISuggestionsView(HomeAssistantView):
     """View to handle OpenAI Suggestions requests."""
@@ -162,39 +167,31 @@ class OpenAISuggestionsView(HomeAssistantView):
         """Handle POST request for OpenAI suggestions."""
         hass = request.app["hass"]
         data = await request.json()
-        
+
         entities = data.get("entities", [])
-        
+
         if not entities:
-            return self.json(
-                {"success": False, "error": "No entities provided"}, 
-                status_code=400
-            )
-        
+            return self.json({"success": False, "error": "No entities provided"}, status_code=400)
+
         try:
             import openai
-            
+
             # Get API key from config
             config_entries = hass.config_entries.async_entries(DOMAIN)
             if not config_entries:
                 return self.json(
-                    {"success": False, "error": "Integration not configured"}, 
-                    status_code=400
+                    {"success": False, "error": "Integration not configured"}, status_code=400
                 )
-            
+
             api_key = config_entries[0].data.get("api_key")
             if not api_key:
                 return self.json(
-                    {"success": False, "error": "OpenAI API key not configured"}, 
-                    status_code=400
+                    {"success": False, "error": "OpenAI API key not configured"}, status_code=400
                 )
-            
+
             # Initialize client with explicit parameters to avoid environment issues
             try:
-                client = openai.OpenAI(
-                    api_key=api_key,
-                    timeout=30.0
-                )
+                client = openai.OpenAI(api_key=api_key, timeout=30.0)
             except TypeError as init_error:
                 # Fallbacks for older versions or environment issues
                 _LOGGER.warning(
@@ -214,80 +211,85 @@ class OpenAISuggestionsView(HomeAssistantView):
                         api_key=api_key,
                         http_client=httpx.Client(timeout=30.0),
                     )
-            
+
             # Prepare the prompt
-            prompt = "Suggest better, more descriptive names for the following Home Assistant entities. "
-            prompt += "The names should be clear, concise, and descriptive of the entity's function and location. "
-            prompt += "Return only a JSON array with the suggested names in the same order as the input entities.\n\n"
-            
+            prompt = (
+                "Suggest concise Home Assistant entity IDs using "
+                "`<domain>.<location_code>_<device_type>_<function>_<identifier>`. "
+                "Use lowercase letters, numbers and underscores, "
+                "and do not begin or end an ID with an underscore. "
+                "Return only a JSON array of `entity_id` strings "
+                "in the original order.\n\n"
+            )
+
             for entity in entities:
                 prompt += f"Entity ID: {entity['entity_id']}\n"
                 prompt += f"Current Name: {entity['name']}\n"
                 prompt += f"Device: {entity['device_name']}\n"
                 prompt += f"Area: {entity['area_name']}\n\n"
-            
+
             # Call OpenAI API
             response = await hass.async_add_executor_job(
                 lambda: client.chat.completions.create(
                     model="gpt-4",
                     messages=[
-                        {"role": "system", "content": "You are a helpful assistant that suggests clear, concise names for Home Assistant entities."},
-                        {"role": "user", "content": prompt}
+                        {
+                            "role": "system",
+                            "content": (
+                                "You are a helpful assistant that suggests concise Home Assistant "
+                                "entity IDs following a standardized naming template."
+                            ),
+                        },
+                        {"role": "user", "content": prompt},
                     ],
                     temperature=0.7,
                 )
             )
-            
+
             # Parse the response
             try:
                 content = response.choices[0].message.content
                 # Extract JSON from the response
                 import re
-                json_match = re.search(r'\[.*\]', content, re.DOTALL)
+
+                json_match = re.search(r"\[.*\]", content, re.DOTALL)
                 if json_match:
                     suggestions = json.loads(json_match.group(0))
                 else:
                     suggestions = json.loads(content)
-                
+
                 # Ensure we have the right number of suggestions
                 if len(suggestions) != len(entities):
                     return self.json(
-                        {"success": False, "error": "Received incorrect number of suggestions"}, 
-                        status_code=500
+                        {"success": False, "error": "Received incorrect number of suggestions"},
+                        status_code=500,
                     )
-                
+
                 # Combine original entities with suggestions
                 result = []
                 for i, entity in enumerate(entities):
-                    result.append({
-                        **entity,
-                        "suggested_name": suggestions[i]
-                    })
-                
+                    result.append({**entity, "suggested_id": suggestions[i]})
+
                 return self.json({"success": True, "suggestions": result})
-            
+
             except json.JSONDecodeError:
                 return self.json(
-                    {"success": False, "error": "Failed to parse OpenAI response"}, 
-                    status_code=500
+                    {"success": False, "error": "Failed to parse OpenAI response"}, status_code=500
                 )
-            
+
         except ImportError:
             return self.json(
-                {"success": False, "error": "OpenAI package not installed"}, 
-                status_code=500
+                {"success": False, "error": "OpenAI package not installed"}, status_code=500
             )
         except Exception as e:
             _LOGGER.error("Error getting suggestions: %s", e)
-            return self.json(
-                {"success": False, "error": str(e)}, 
-                status_code=500
-            )
+            return self.json({"success": False, "error": str(e)}, status_code=500)
+
 
 async def apply_rename_service(hass, service):
     """Apply rename service call."""
     entity_id = service.data.get("entity_id")
     new_name = service.data.get("new_name")
-    
+
     registry = er.async_get(hass)
     registry.async_update_entity(entity_id, name=new_name)

--- a/custom_components/entity_renamer/frontend/entity-renamer-panel.js
+++ b/custom_components/entity_renamer/frontend/entity-renamer-panel.js
@@ -63,16 +63,16 @@ class EntityRenamerPanel extends LitElement {
         const data = await response.json();
         this.entities = data;
         this.filteredEntities = [...data];
-        
+
         // Extract unique areas and devices for filters
         const areaSet = new Set();
         const deviceSet = new Set();
-        
+
         this.entities.forEach(entity => {
           if (entity.area_name) areaSet.add(entity.area_name);
           if (entity.device_name) deviceSet.add(entity.device_name);
         });
-        
+
         this.areas = Array.from(areaSet).sort();
         this.devices = Array.from(deviceSet).sort();
       } else {
@@ -87,13 +87,13 @@ class EntityRenamerPanel extends LitElement {
 
   applyFilters() {
     this.filteredEntities = this.entities.filter(entity => {
-      const matchesSearch = !this.searchTerm || 
+      const matchesSearch = !this.searchTerm ||
         entity.entity_id.toLowerCase().includes(this.searchTerm.toLowerCase()) ||
         (entity.name && entity.name.toLowerCase().includes(this.searchTerm.toLowerCase()));
-      
+
       const matchesArea = !this.filterArea || entity.area_name === this.filterArea;
       const matchesDevice = !this.filterDevice || entity.device_name === this.filterDevice;
-      
+
       return matchesSearch && matchesArea && matchesDevice;
     });
   }
@@ -138,7 +138,7 @@ class EntityRenamerPanel extends LitElement {
 
     this.suggestionsLoading = true;
     this.suggestions = [];
-    
+
     try {
       const headers = {
         "Content-Type": "application/json",
@@ -153,9 +153,9 @@ class EntityRenamerPanel extends LitElement {
           entities: this.selectedEntities,
         }),
       });
-      
+
       const data = await response.json();
-      
+
       if (data.success) {
         this.suggestions = data.suggestions;
         this.showMessage("Suggestions received successfully", "success");
@@ -169,7 +169,7 @@ class EntityRenamerPanel extends LitElement {
     }
   }
 
-  async applyRename(entity, suggestedName) {
+  async applyRename(entity, suggestedId) {
     try {
       const headers = {
         "Content-Type": "application/json",
@@ -182,28 +182,33 @@ class EntityRenamerPanel extends LitElement {
         headers,
         body: JSON.stringify({
           entity_id: entity.entity_id,
-          new_name: suggestedName,
+          new_name: suggestedId,
         }),
       });
-      
+
       const data = await response.json();
-      
+
       if (data.success) {
         // Update the entity in our local list
-        const updatedEntities = this.entities.map(e => {
+        const updatedEntities = this.entities.map((e) => {
           if (e.entity_id === entity.entity_id) {
-            return { ...e, name: suggestedName };
+            return { ...e, name: suggestedId };
           }
           return e;
         });
-        
+
         this.entities = updatedEntities;
         this.applyFilters();
-        
+
         // Remove from suggestions
-        this.suggestions = this.suggestions.filter(s => s.entity_id !== entity.entity_id);
-        
-        this.showMessage(`Renamed ${entity.entity_id} successfully`, "success");
+        this.suggestions = this.suggestions.filter(
+          (s) => s.entity_id !== entity.entity_id
+        );
+
+        this.showMessage(
+          `Renamed ${entity.entity_id} successfully`,
+          "success"
+        );
       } else {
         this.showMessage(`Error: ${data.error}`, "error");
       }
@@ -224,37 +229,39 @@ class EntityRenamerPanel extends LitElement {
     if (this.hass && this.hass.auth && this.hass.auth.accessToken) {
       headers["Authorization"] = `Bearer ${this.hass.auth.accessToken}`;
     }
-    const promises = this.suggestions.map(suggestion => 
+    const promises = this.suggestions.map((suggestion) =>
       fetch("/api/entity_renamer/rename", {
         method: "POST",
         headers,
         body: JSON.stringify({
           entity_id: suggestion.entity_id,
-          new_name: suggestion.suggested_name,
+          new_name: suggestion.suggested_id,
         }),
       })
     );
-    
+
     try {
       const results = await Promise.all(promises);
       const allSuccessful = results.every(r => r.ok);
-      
+
       if (allSuccessful) {
         // Update all entities in our local list
-        const updatedEntities = this.entities.map(entity => {
-          const suggestion = this.suggestions.find(s => s.entity_id === entity.entity_id);
+        const updatedEntities = this.entities.map((entity) => {
+          const suggestion = this.suggestions.find(
+            (s) => s.entity_id === entity.entity_id
+          );
           if (suggestion) {
-            return { ...entity, name: suggestion.suggested_name };
+            return { ...entity, name: suggestion.suggested_id };
           }
           return entity;
         });
-        
+
         this.entities = updatedEntities;
         this.applyFilters();
-        
+
         // Clear suggestions
         this.suggestions = [];
-        
+
         this.showMessage("All suggestions applied successfully", "success");
       } else {
         this.showMessage("Some renames failed, please try again", "error");
@@ -267,7 +274,7 @@ class EntityRenamerPanel extends LitElement {
   showMessage(message, type = "info") {
     this.message = message;
     this.messageType = type;
-    
+
     // Clear message after 5 seconds
     setTimeout(() => {
       this.message = "";
@@ -283,7 +290,7 @@ class EntityRenamerPanel extends LitElement {
               ${this.message}
             </div>
           ` : ""}
-          
+
           <div class="filters">
             <div class="search-box">
               <ha-icon icon="mdi:magnify"></ha-icon>
@@ -294,7 +301,7 @@ class EntityRenamerPanel extends LitElement {
                 .value=${this.searchTerm}
               />
             </div>
-            
+
             <div class="filter-selects">
               <select @change=${this.handleAreaFilter} .value=${this.filterArea}>
                 <option value="">All Areas</option>
@@ -302,7 +309,7 @@ class EntityRenamerPanel extends LitElement {
                   <option value=${area}>${area}</option>
                 `)}
               </select>
-              
+
               <select @change=${this.handleDeviceFilter} .value=${this.filterDevice}>
                 <option value="">All Devices</option>
                 ${this.devices.map(device => html`
@@ -311,7 +318,7 @@ class EntityRenamerPanel extends LitElement {
               </select>
             </div>
           </div>
-          
+
           ${this.loading ? html`
             <div class="loading">
               <ha-circular-progress active></ha-circular-progress>
@@ -323,8 +330,8 @@ class EntityRenamerPanel extends LitElement {
                 <thead>
                   <tr>
                     <th class="select-col">
-                      <input 
-                        type="checkbox" 
+                      <input
+                        type="checkbox"
                         ?checked=${this.selectedEntities.length === this.filteredEntities.length && this.filteredEntities.length > 0}
                         @change=${() => this.selectedEntities.length === this.filteredEntities.length ? this.clearSelection() : this.selectAll()}
                       />
@@ -340,12 +347,12 @@ class EntityRenamerPanel extends LitElement {
                     <tr>
                       <td colspan="5" class="no-entities">No entities found</td>
                     </tr>
-                  ` : 
+                  ` :
                   this.filteredEntities.map(entity => html`
                     <tr class="${this.selectedEntities.some(e => e.entity_id === entity.entity_id) ? 'selected' : ''}">
                       <td>
-                        <input 
-                          type="checkbox" 
+                        <input
+                          type="checkbox"
                           ?checked=${this.selectedEntities.some(e => e.entity_id === entity.entity_id)}
                           @change=${() => this.toggleSelectEntity(entity)}
                         />
@@ -359,27 +366,29 @@ class EntityRenamerPanel extends LitElement {
                 </tbody>
               </table>
             </div>
-            
+
             <div class="actions">
               <span>${this.selectedEntities.length} entities selected</span>
               <div class="button-highlight-message">
-                <strong>This is the "Get Name Suggestions" button ↓</strong>
+                <strong>This is the "Get ID Suggestions" button ↓</strong>
               </div>
               <button
                 class="primary get-suggestions-highlight"
                 ?disabled=${this.selectedEntities.length === 0 || this.suggestionsLoading}
                 @click=${this.getSuggestions}
               >
-                ${this.suggestionsLoading ? html`
-                  <ha-circular-progress active size="small"></ha-circular-progress>
-                  Getting suggestions...
-                ` : "Get Name Suggestions"}
+                ${this.suggestionsLoading
+                  ? html`
+                      <ha-circular-progress active size="small"></ha-circular-progress>
+                      Getting suggestions...
+                    `
+                  : "Get ID Suggestions"}
               </button>
             </div>
-            
+
             ${this.suggestions.length > 0 ? html`
               <div class="suggestions-section">
-                <h3>Suggested Names</h3>
+                <h3>Suggested Entity IDs</h3>
                 <div class="suggestions-table-container">
                   <table class="suggestions-table">
                     <thead>
@@ -387,7 +396,7 @@ class EntityRenamerPanel extends LitElement {
                         <th>Area</th>
                         <th>Device</th>
                         <th>Current Name</th>
-                        <th>Suggested Name</th>
+                        <th>Suggested Entity ID</th>
                         <th>Actions</th>
                       </tr>
                     </thead>
@@ -397,11 +406,12 @@ class EntityRenamerPanel extends LitElement {
                           <td>${suggestion.area_name}</td>
                           <td>${suggestion.device_name}</td>
                           <td>${suggestion.name}</td>
-                          <td>${suggestion.suggested_name}</td>
+                          <td>${suggestion.suggested_id}</td>
                           <td>
                             <button
                               class="apply-button"
-                              @click=${() => this.applyRename(suggestion, suggestion.suggested_name)}
+                              @click=${() =>
+                                this.applyRename(suggestion, suggestion.suggested_id)}
                             >
                               Apply
                             </button>
@@ -434,54 +444,54 @@ class EntityRenamerPanel extends LitElement {
         padding: 16px;
         font-family: var(--primary-font-family, "Roboto", "system-ui", "sans-serif");
       }
-      
+
       ha-card {
         width: 100%;
         max-width: 1200px;
         margin: 0 auto;
       }
-      
+
       .card-content {
         padding: 16px;
       }
-      
+
       .message {
         padding: 10px;
         margin-bottom: 16px;
         border-radius: 4px;
       }
-      
+
       .message.error {
         background-color: #FFF5F5;
         color: #C53030;
         border: 1px solid #FEB2B2;
       }
-      
+
       .message.success {
         background-color: #F0FFF4;
         color: #276749;
         border: 1px solid #C6F6D5;
       }
-      
+
       .message.warning {
         background-color: #FFFAF0;
         color: #C05621;
         border: 1px solid #FEEBC8;
       }
-      
+
       .message.info {
         background-color: #EBF8FF;
         color: #2C5282;
         border: 1px solid #BEE3F8;
       }
-      
+
       .filters {
         display: flex;
         flex-wrap: wrap;
         gap: 16px;
         margin-bottom: 16px;
       }
-      
+
       .search-box {
         display: flex;
         align-items: center;
@@ -491,7 +501,7 @@ class EntityRenamerPanel extends LitElement {
         border-radius: 4px;
         padding: 0 8px;
       }
-      
+
       .search-box input {
         flex: 1;
         border: none;
@@ -499,12 +509,12 @@ class EntityRenamerPanel extends LitElement {
         background: transparent;
         color: var(--primary-text-color);
       }
-      
+
       .filter-selects {
         display: flex;
         gap: 8px;
       }
-      
+
       .filter-selects select {
         padding: 8px;
         border: 1px solid var(--divider-color, #e0e0e0);
@@ -512,7 +522,7 @@ class EntityRenamerPanel extends LitElement {
         background: var(--card-background-color, white);
         color: var(--primary-text-color);
       }
-      
+
       .loading {
         display: flex;
         flex-direction: column;
@@ -520,42 +530,42 @@ class EntityRenamerPanel extends LitElement {
         justify-content: center;
         padding: 32px;
       }
-      
+
       .entity-table-container, .suggestions-table-container {
         overflow-x: auto;
         margin-bottom: 16px;
       }
-      
+
       table {
         width: 100%;
         border-collapse: collapse;
       }
-      
+
       th, td {
         text-align: left;
         padding: 8px 16px;
         border-bottom: 1px solid var(--divider-color, #e0e0e0);
       }
-      
+
       th {
         font-weight: 500;
         background-color: var(--secondary-background-color, #f5f5f5);
       }
-      
+
       tr.selected {
         background-color: var(--light-primary-color, #D1E3FF);
       }
-      
+
       .select-col {
         width: 50px;
       }
-      
+
       .no-entities {
         text-align: center;
         padding: 32px;
         color: var(--secondary-text-color);
       }
-      
+
       .actions {
         display: flex;
         flex-direction: column;
@@ -586,7 +596,7 @@ class EntityRenamerPanel extends LitElement {
         box-shadow: 0 2px 12px rgba(2,136,209,0.15);
         margin-top: 4px;
       }
-      
+
       button {
         cursor: pointer;
         border: none;
@@ -597,7 +607,7 @@ class EntityRenamerPanel extends LitElement {
         font-family: inherit;
         transition: background 0.2s, color 0.2s;
       }
-      
+
       button.primary {
         background-color: var(--primary-color, #03a9f4);
         color: var(--text-primary-color, #fff);
@@ -605,30 +615,30 @@ class EntityRenamerPanel extends LitElement {
         font-weight: 600;
         box-shadow: 0 2px 8px rgba(0,0,0,0.08);
       }
-      
+
       button:disabled {
         opacity: 0.5;
         cursor: not-allowed;
       }
-      
+
       .apply-button {
         background-color: var(--primary-color, #03a9f4);
         color: var(--text-primary-color, #fff);
         padding: 4px 8px;
         font-size: 0.9em;
       }
-      
+
       .suggestions-section {
         margin-top: 24px;
         border-top: 1px solid var(--divider-color, #e0e0e0);
         padding-top: 16px;
       }
-      
+
       .suggestions-section h3 {
         margin-top: 0;
         margin-bottom: 16px;
       }
-      
+
       .apply-all {
         display: flex;
         justify-content: flex-end;

--- a/custom_components/entity_renamer/frontend/index.html
+++ b/custom_components/entity_renamer/frontend/index.html
@@ -12,18 +12,18 @@
       background-color: #f5f5f5;
       color: #212121;
     }
-    
+
     .container {
       max-width: 1200px;
       margin: 0 auto;
       padding: 20px;
     }
-    
+
     h1 {
       margin-top: 0;
       color: #03a9f4;
     }
-    
+
     .note {
       background-color: #fff3cd;
       border: 1px solid #ffeeba;
@@ -32,7 +32,7 @@
       border-radius: 4px;
       margin-bottom: 20px;
     }
-    
+
     .mock-data {
       background-color: #e8f5e9;
       border: 1px solid #c8e6c9;
@@ -41,7 +41,7 @@
       border-radius: 4px;
       margin-bottom: 20px;
     }
-    
+
     pre {
       background-color: #f8f9fa;
       border: 1px solid #e9ecef;
@@ -49,7 +49,7 @@
       padding: 15px;
       overflow: auto;
     }
-    
+
     code {
       font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
       font-size: 14px;
@@ -108,13 +108,13 @@
           } else if (url === "/api/entity_renamer/suggest") {
             const body = JSON.parse(options.body);
             const entities = body.entities;
-            
+
             // Generate mock suggestions
             const suggestions = entities.map(entity => ({
               ...entity,
-              suggested_name: `${entity.area_name} ${entity.device_name} ${entity.entity_id.split('.')[0]}`
+              suggested_id: `${entity.entity_id}`
             }));
-            
+
             resolve({
               ok: true,
               json: () => Promise.resolve({
@@ -154,27 +154,27 @@
 <body>
   <div class="container">
     <h1>AI Entity Renamer - Test Page</h1>
-    
+
     <div class="note">
-      <strong>Note:</strong> This is a test page for the AI Entity Renamer panel. In a real Home Assistant environment, 
+      <strong>Note:</strong> This is a test page for the AI Entity Renamer panel. In a real Home Assistant environment,
       the panel would be loaded within the Home Assistant UI and have access to real entity data.
     </div>
-    
+
     <div class="mock-data">
       <strong>Mock Data:</strong> This page uses mock data for testing. The API calls are simulated.
     </div>
-    
+
     <entity-renamer-panel></entity-renamer-panel>
-    
+
     <h2>Developer Information</h2>
     <p>
       This test page allows you to preview the AI Entity Renamer panel UI without needing to install it in Home Assistant.
       The panel is using mock data and simulated API responses.
     </p>
-    
+
     <h3>Mock Entities</h3>
     <pre><code id="mockEntitiesJson"></code></pre>
-    
+
     <script>
       document.getElementById('mockEntitiesJson').textContent = JSON.stringify(mockEntities, null, 2);
     </script>


### PR DESCRIPTION
## Summary
- update OpenAI prompt to recommend standardized entity IDs
- display and apply suggested entity IDs in the UI
- document template-based entity ID suggestions

## Testing
- `pre-commit run --files README.md custom_components/entity_renamer/README.md custom_components/entity_renamer/__init__.py custom_components/entity_renamer/frontend/entity-renamer-panel.js custom_components/entity_renamer/frontend/index.html`
- `pytest` *(fails: RuntimeError no running event loop)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1364aad88329b37e93d9e3e3cd35