### PR TITLE
feat: add device renaming support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Device renaming support with new backend API endpoints
+- OpenAI-powered device name suggestions
+- Frontend table for selecting devices and applying name suggestions
+- `apply_device_rename` service for programmatic device updates
+
 ## [1.0.0] - 2025-04-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A custom component for Home Assistant that allows you to bulk rename entities using OpenAI suggestions.
+A custom component for Home Assistant that allows you to bulk rename entities and devices using OpenAI suggestions.
 
 ![AI Entity Renamer Screenshot](docs/screenshot.png)
 
@@ -12,23 +12,25 @@ A custom component for Home Assistant that allows you to bulk rename entities us
 Managing entity names in Home Assistant can become tedious as your smart home grows. This integration provides a user-friendly interface to:
 
 - View all entities with their area, device, name, and entity ID
+- View devices with area, manufacturer and model information
 - Entities are grouped by area with collapsible headers for easier navigation
 - Filter and search for specific entities
-- Select multiple entities for bulk renaming
-- Get AI-powered entity ID suggestions from OpenAI following a structured naming template
-- Apply suggested IDs and friendly names individually or all at once
+- Select multiple entities or devices for bulk renaming
+- Get AI-powered entity ID or device name suggestions from OpenAI
+- Apply suggested IDs and friendly names or device names individually or all at once
 
 The integration adds a dedicated sidebar icon for easy access and provides a clean, intuitive interface for managing your entity names.
 
 ## Features
 
 - **Entity Browser**: View and filter all entities in your Home Assistant instance
+- **Device Browser**: Review devices with area, manufacturer and model details
 - **Collapsible Area Groups**: Entities are grouped by area with expandable headers to keep large lists manageable
-- **Bulk Selection**: Select multiple entities for batch operations
+- **Bulk Selection**: Select multiple entities or devices for batch operations
 - **AI Suggestions**: Get intelligent naming suggestions from OpenAI
 - **Bulk Apply**: Apply all suggestions at once or selectively choose which to apply
 - **Sidebar Integration**: Access via a dedicated sidebar icon
-- **Service API**: Programmatically rename entities via service calls
+- **Service API**: Programmatically rename entities or devices via service calls
 
 ## Installation
 
@@ -61,10 +63,10 @@ Once installed, the integration will automatically maintain its version informat
 
 1. After installation, you'll see a new "AI Entity Renamer" icon in your Home Assistant sidebar
 2. Click on it to open the AI Entity Renamer interface
-3. Browse or search for entities you want to rename
-4. Select the entities you want to rename
-5. Click "Get ID Suggestions" to receive AI-generated entity ID suggestions
-6. Review the suggestions and apply them individually or all at once. Applying a suggestion updates both the entity ID and its friendly name based on the suggested ID.
+3. Browse or search for entities or devices you want to rename
+4. Select the entities or devices you want to rename
+5. Click "Get ID Suggestions" or "Get Name Suggestions" to receive AI-generated suggestions
+6. Review the suggestions and apply them individually or all at once. Applying an entity suggestion updates both the entity ID and its friendly name; applying a device suggestion updates the device name.
 
 ### How naming suggestions work
 
@@ -88,7 +90,7 @@ from each ID so you can confirm the change before applying it.
 
 ## Privacy
 
-This integration sends entity information (entity ID, current name, device name, and area name) to OpenAI to generate name suggestions. No other data from your Home Assistant instance is shared.
+This integration sends entity or device information (such as entity ID, current name, device name, manufacturer, model, and area name) to OpenAI to generate name suggestions. No other data from your Home Assistant instance is shared.
 
 ## Contributing
 

--- a/custom_components/entity_renamer/README.md
+++ b/custom_components/entity_renamer/README.md
@@ -1,15 +1,16 @@
 # AI Entity Renamer for Home Assistant
 
-A custom component for Home Assistant that allows you to bulk rename entities using OpenAI suggestions.
+A custom component for Home Assistant that allows you to bulk rename entities and devices using OpenAI suggestions.
 
 ## Features
 
 - View all entities in your Home Assistant instance with their area, device, name, and entity ID
+- View devices with their area, manufacturer, and model
 - Group entities by area with collapsible headers to handle large lists
 - Filter entities by area, device, or search term
-- Select multiple entities for bulk renaming
-- Get AI-powered entity ID suggestions from OpenAI following a structured naming template
-- Apply suggested IDs and friendly names individually or all at once
+- Select multiple entities or devices for bulk renaming
+- Get AI-powered entity ID or device name suggestions from OpenAI following a structured naming template
+- Apply suggested IDs and friendly names or device names individually or all at once
 - Access via a dedicated sidebar icon
 
 ## Installation
@@ -47,8 +48,8 @@ Once installed, the integration will automatically maintain its version informat
 2. Click on it to open the AI Entity Renamer interface
 3. Browse or search for entities you want to rename
 4. Select the entities you want to rename
-5. Click "Get ID Suggestions" to receive AI-generated entity ID suggestions
-6. Review the suggestions and apply them individually or all at once. When a suggestion is applied, the entity's ID and friendly name are updated to match the template.
+5. Click "Get ID Suggestions" or "Get Name Suggestions" to receive AI-generated suggestions
+6. Review the suggestions and apply them individually or all at once. When an entity suggestion is applied, the entity's ID and friendly name are updated to match the template. When a device suggestion is applied, the device's name is updated.
 
 ### How naming suggestions work
 
@@ -66,21 +67,31 @@ each ID so you can review the proposed change.
 
 ## Services
 
-The integration provides the following service:
+The integration provides the following services:
 
 - `entity_renamer.apply_rename`: Rename a specific entity
   - `entity_id`: The current entity ID
   - `new_entity_id`: The new entity ID
   - `new_name` (optional): The friendly name to apply
+- `entity_renamer.apply_device_rename`: Rename a specific device
+  - `device_id`: The device ID
+  - `new_name`: The new device name
 
 Example service call:
 
 ```yaml
+# Rename an entity
 service: entity_renamer.apply_rename
 data:
   entity_id: light.living_room
   new_entity_id: light.lr_ceiling_light
   new_name: "LR Ceiling Light"
+
+# Rename a device
+service: entity_renamer.apply_device_rename
+data:
+  device_id: 123456abcdef
+  new_name: "Living Room Sensor"
 ```
 
 ## Versioning

--- a/custom_components/entity_renamer/frontend/entity-renamer-panel.js
+++ b/custom_components/entity_renamer/frontend/entity-renamer-panel.js
@@ -24,6 +24,10 @@ class EntityRenamerPanel extends LitElement {
       messageType: { type: String },
       areas: { type: Array },
       devices: { type: Array },
+      deviceList: { type: Array },
+      selectedDevices: { type: Array },
+      deviceSuggestions: { type: Array },
+      deviceSuggestionsLoading: { type: Boolean },
     };
   }
 
@@ -42,11 +46,16 @@ class EntityRenamerPanel extends LitElement {
     this.messageType = "info";
     this.areas = [];
     this.devices = [];
+    this.deviceList = [];
+    this.selectedDevices = [];
+    this.deviceSuggestions = [];
+    this.deviceSuggestionsLoading = false;
   }
 
   connectedCallback() {
     super.connectedCallback();
     this.loadEntities();
+    this.loadDevices();
   }
 
   async loadEntities() {
@@ -111,6 +120,145 @@ class EntityRenamerPanel extends LitElement {
   handleDeviceFilter(e) {
     this.filterDevice = e.target.value;
     this.applyFilters();
+  }
+
+  async loadDevices() {
+    try {
+      const headers = {};
+      if (this.hass && this.hass.auth && this.hass.auth.accessToken) {
+        headers["Authorization"] = `Bearer ${this.hass.auth.accessToken}`;
+      }
+      const response = await fetch("/api/entity_renamer/devices", { headers });
+      if (response.ok) {
+        const data = await response.json();
+        this.deviceList = data;
+      } else {
+        this.showMessage("Failed to load devices", "error");
+      }
+    } catch (error) {
+      this.showMessage(`Error: ${error.message}`, "error");
+    }
+  }
+
+  toggleSelectDevice(device) {
+    const index = this.selectedDevices.findIndex((d) => d.id === device.id);
+    if (index === -1) {
+      this.selectedDevices = [...this.selectedDevices, device];
+    } else {
+      this.selectedDevices = this.selectedDevices.filter((d) => d.id !== device.id);
+    }
+  }
+
+  selectAllDevices() {
+    this.selectedDevices = [...this.deviceList];
+  }
+
+  clearDeviceSelection() {
+    this.selectedDevices = [];
+  }
+
+  async getDeviceSuggestions() {
+    if (this.selectedDevices.length === 0) {
+      this.showMessage("Please select at least one device", "warning");
+      return;
+    }
+
+    this.deviceSuggestionsLoading = true;
+    this.deviceSuggestions = [];
+
+    try {
+      const headers = { "Content-Type": "application/json" };
+      if (this.hass && this.hass.auth && this.hass.auth.accessToken) {
+        headers["Authorization"] = `Bearer ${this.hass.auth.accessToken}`;
+      }
+      const response = await fetch("/api/entity_renamer/suggest_device", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ devices: this.selectedDevices }),
+      });
+      const data = await response.json();
+
+      if (data.success) {
+        this.deviceSuggestions = data.suggestions;
+        this.showMessage("Device suggestions received successfully", "success");
+      } else {
+        this.showMessage(`Error: ${data.error}`, "error");
+      }
+    } catch (error) {
+      this.showMessage(`Error: ${error.message}`, "error");
+    } finally {
+      this.deviceSuggestionsLoading = false;
+    }
+  }
+
+  async applyDeviceRename(device, suggestedName) {
+    try {
+      const headers = { "Content-Type": "application/json" };
+      if (this.hass && this.hass.auth && this.hass.auth.accessToken) {
+        headers["Authorization"] = `Bearer ${this.hass.auth.accessToken}`;
+      }
+      const response = await fetch("/api/entity_renamer/rename_device", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ device_id: device.id, new_name: suggestedName }),
+      });
+
+      const data = await response.json();
+      if (data.success) {
+        this.deviceList = this.deviceList.map((d) =>
+          d.id === device.id ? { ...d, name: suggestedName } : d
+        );
+        this.deviceSuggestions = this.deviceSuggestions.filter((d) => d.id !== device.id);
+        this.selectedDevices = this.selectedDevices.filter((d) => d.id !== device.id);
+        this.showMessage(`Renamed device ${device.name} successfully`, "success");
+      } else {
+        this.showMessage(`Error: ${data.error}`, "error");
+      }
+    } catch (error) {
+      this.showMessage(`Error: ${error.message}`, "error");
+    }
+  }
+
+  async applyAllDeviceSuggestions() {
+    if (this.deviceSuggestions.length === 0) {
+      this.showMessage("No device suggestions to apply", "warning");
+      return;
+    }
+
+    const headers = { "Content-Type": "application/json" };
+    if (this.hass && this.hass.auth && this.hass.auth.accessToken) {
+      headers["Authorization"] = `Bearer ${this.hass.auth.accessToken}`;
+    }
+
+    const promises = this.deviceSuggestions.map((suggestion) =>
+      fetch("/api/entity_renamer/rename_device", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ device_id: suggestion.id, new_name: suggestion.suggested_name }),
+      })
+    );
+
+    try {
+      const results = await Promise.all(promises);
+      const allSuccessful = results.every((r) => r.ok);
+
+      if (allSuccessful) {
+        this.deviceList = this.deviceList.map((device) => {
+          const suggestion = this.deviceSuggestions.find((s) => s.id === device.id);
+          if (suggestion) {
+            return { ...device, name: suggestion.suggested_name };
+          }
+          return device;
+        });
+        this.deviceSuggestions = [];
+        this.selectedDevices = [];
+        this.showMessage("All device suggestions applied successfully", "success");
+      } else {
+        this.showMessage("Some device renames failed, please try again", "error");
+      }
+    } catch (error) {
+      this.showMessage(`Error: ${error.message}`, "error");
+    }
   }
 
   toggleSelectEntity(entity) {
@@ -490,6 +638,131 @@ class EntityRenamerPanel extends LitElement {
                 </div>
               </div>
             ` : ""}
+            <hr />
+            <h2>Devices</h2>
+            <div class="entity-table-container">
+              <div class="select-all-row">
+                <input
+                  type="checkbox"
+                  ?checked=${this.selectedDevices.length === this.deviceList.length && this.deviceList.length > 0}
+                  @change=${() =>
+                    this.selectedDevices.length === this.deviceList.length
+                      ? this.clearDeviceSelection()
+                      : this.selectAllDevices()}
+                />
+                <span>Select All</span>
+              </div>
+
+              ${this.deviceList.length === 0
+                ? html`<div class="no-entities">No devices found</div>`
+                : html`
+                    <table class="entity-table device-table">
+                      <thead>
+                        <tr>
+                          <th class="select-col"></th>
+                          <th>Area</th>
+                          <th>Name</th>
+                          <th>Manufacturer</th>
+                          <th>Model</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        ${this.deviceList.map(
+                          (device) => html`
+                            <tr class="${this.selectedDevices.some(
+                              (d) => d.id === device.id
+                            )
+                              ? 'selected'
+                              : ''}">
+                              <td>
+                                <input
+                                  type="checkbox"
+                                  ?checked=${this.selectedDevices.some(
+                                    (d) => d.id === device.id
+                                  )}
+                                  @change=${() => this.toggleSelectDevice(device)}
+                                />
+                              </td>
+                              <td>${device.area_name}</td>
+                              <td>${device.name}</td>
+                              <td>${device.manufacturer}</td>
+                              <td>${device.model}</td>
+                            </tr>
+                          `
+                        )}
+                      </tbody>
+                    </table>
+                  `}
+            </div>
+
+            <div class="actions">
+              <span>${this.selectedDevices.length} devices selected</span>
+              <button
+                class="primary"
+                ?disabled=${
+                  this.selectedDevices.length === 0 || this.deviceSuggestionsLoading
+                }
+                @click=${this.getDeviceSuggestions}
+              >
+                ${this.deviceSuggestionsLoading
+                  ? html`
+                      <ha-circular-progress active size="small"></ha-circular-progress>
+                      Getting suggestions...
+                    `
+                  : "Get Name Suggestions"}
+              </button>
+            </div>
+
+            ${this.deviceSuggestions.length > 0
+              ? html`
+                  <div class="suggestions-section">
+                    <h3>Suggested Device Names</h3>
+                    <div class="suggestions-table-container">
+                      <table class="suggestions-table device-suggestions-table">
+                        <thead>
+                          <tr>
+                            <th>Area</th>
+                            <th>Current Name</th>
+                            <th>Suggested Name</th>
+                            <th>Actions</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          ${this.deviceSuggestions.map(
+                            (suggestion) => html`
+                              <tr>
+                                <td>${suggestion.area_name}</td>
+                                <td>${suggestion.name}</td>
+                                <td>${suggestion.suggested_name}</td>
+                                <td>
+                                  <button
+                                    class="apply-button"
+                                    @click=${() =>
+                                      this.applyDeviceRename(
+                                        suggestion,
+                                        suggestion.suggested_name
+                                      )}
+                                  >
+                                    Apply
+                                  </button>
+                                </td>
+                              </tr>
+                            `
+                          )}
+                        </tbody>
+                      </table>
+                    </div>
+                    <div class="apply-all">
+                      <button
+                        class="primary"
+                        @click=${this.applyAllDeviceSuggestions}
+                      >
+                        Apply All Suggestions
+                      </button>
+                    </div>
+                  </div>
+                `
+              : ""}
           `}
         </div>
       </ha-card>

--- a/custom_components/entity_renamer/services.yaml
+++ b/custom_components/entity_renamer/services.yaml
@@ -23,3 +23,22 @@ apply_rename:
       example: "LR Ceiling Light"
       selector:
         text: {}
+
+apply_device_rename:
+  name: Apply Device Rename
+  description: Rename a Home Assistant device.
+  fields:
+    device_id:
+      name: Device ID
+      description: The device ID to rename.
+      required: true
+      example: "123456abcdef"
+      selector:
+        text: {}
+    new_name:
+      name: New Name
+      description: The new device name.
+      required: true
+      example: "Living Room Sensor"
+      selector:
+        text: {}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,23 +1,28 @@
 """Tests for AI Entity Renamer integration."""
+
 import os
 import sys
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from homeassistant.setup import async_setup_component
+
 from custom_components.entity_renamer import DOMAIN
 
 
 @pytest.mark.asyncio
 async def test_setup(hass):
     """Test the setup of the integration."""
-    with patch("custom_components.entity_renamer.frontend.async_register_built_in_panel"), \
-         patch("custom_components.entity_renamer.EntityListView"), \
-         patch("custom_components.entity_renamer.RenameEntityView"), \
-         patch("custom_components.entity_renamer.OpenAISuggestionsView"):
-        
+    with (
+        patch("custom_components.entity_renamer.frontend.async_register_built_in_panel"),
+        patch("custom_components.entity_renamer.EntityListView"),
+        patch("custom_components.entity_renamer.RenameEntityView"),
+        patch("custom_components.entity_renamer.OpenAISuggestionsView"),
+    ):
+
         assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
         assert DOMAIN in hass.data
 
@@ -26,21 +31,33 @@ async def test_setup(hass):
 async def test_apply_rename_service(hass):
     """Test the apply_rename service."""
     from custom_components.entity_renamer import apply_rename_service
-    
+
     # Mock the entity registry
     mock_registry = MagicMock()
     with patch("homeassistant.helpers.entity_registry.async_get", return_value=mock_registry):
         # Create a mock service call
         service = MagicMock()
-        service.data = {
-            "entity_id": "light.test_light",
-            "new_name": "New Light Name"
-        }
-        
+        service.data = {"entity_id": "light.test_light", "new_name": "New Light Name"}
+
         # Call the service
         await apply_rename_service(hass, service)
-        
+
         # Verify the entity was updated
         mock_registry.async_update_entity.assert_called_once_with(
             "light.test_light", name="New Light Name"
         )
+
+
+@pytest.mark.asyncio
+async def test_apply_device_rename_service(hass):
+    """Test the apply_device_rename service."""
+    from custom_components.entity_renamer import apply_device_rename_service
+
+    mock_registry = MagicMock()
+    with patch("homeassistant.helpers.device_registry.async_get", return_value=mock_registry):
+        service = MagicMock()
+        service.data = {"device_id": "abc123", "new_name": "New Device"}
+
+        await apply_device_rename_service(hass, service)
+
+        mock_registry.async_update_device.assert_called_once_with("abc123", name="New Device")


### PR DESCRIPTION
## Summary
- support renaming devices with new API endpoints and OpenAI suggestions
- add frontend UI for device name suggestions and bulk apply
- document new device rename service

## Testing
- `pylint custom_components/entity_renamer/__init__.py tests/test_init.py` *(fails: Useless option value for '--disable', 'C0330' was removed from pylint, see https://github.com/pylint-dev/pylint/pull/3571. (useless-option-value))*
- `pytest --cov=custom_components/entity_renamer --cov-report=xml` *(fails: RuntimeError: no running event loop)*

------
https://chatgpt.com/codex/tasks/task_e_68ab25a248608329b54d953c39608190