### PR TITLE
feat: separate entity and device views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 # Virtual environment
 venv/
 ENV/
+.venv/
 
 # IDE files
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI-powered device name suggestions
 - Frontend table for selecting devices and applying name suggestions
 - `apply_device_rename` service for programmatic device updates
+- Separate tabs for entity and device renaming in the web interface
+- Development requirements now include Home Assistant and pytest-asyncio for testing
 
 ## [1.0.0] - 2025-04-22
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The integration adds a dedicated sidebar icon for easy access and provides a cle
 
 - **Entity Browser**: View and filter all entities in your Home Assistant instance
 - **Device Browser**: Review devices with area, manufacturer and model details
+- **Tabbed Interface**: Switch between dedicated tabs for entities and devices
 - **Collapsible Area Groups**: Entities are grouped by area with expandable headers to keep large lists manageable
 - **Bulk Selection**: Select multiple entities or devices for batch operations
 - **AI Suggestions**: Get intelligent naming suggestions from OpenAI
@@ -63,7 +64,7 @@ Once installed, the integration will automatically maintain its version informat
 
 1. After installation, you'll see a new "AI Entity Renamer" icon in your Home Assistant sidebar
 2. Click on it to open the AI Entity Renamer interface
-3. Browse or search for entities or devices you want to rename
+3. Use the **Entities** and **Devices** tabs to browse for items you want to rename
 4. Select the entities or devices you want to rename
 5. Click "Get ID Suggestions" or "Get Name Suggestions" to receive AI-generated suggestions
 6. Review the suggestions and apply them individually or all at once. Applying an entity suggestion updates both the entity ID and its friendly name; applying a device suggestion updates the device name.

--- a/custom_components/entity_renamer/frontend/entity-renamer-panel.js
+++ b/custom_components/entity_renamer/frontend/entity-renamer-panel.js
@@ -28,6 +28,7 @@ class EntityRenamerPanel extends LitElement {
       selectedDevices: { type: Array },
       deviceSuggestions: { type: Array },
       deviceSuggestionsLoading: { type: Boolean },
+      view: { type: String },
     };
   }
 
@@ -50,6 +51,7 @@ class EntityRenamerPanel extends LitElement {
     this.selectedDevices = [];
     this.deviceSuggestions = [];
     this.deviceSuggestionsLoading = false;
+    this.view = "entities";
   }
 
   connectedCallback() {
@@ -483,12 +485,27 @@ class EntityRenamerPanel extends LitElement {
     return html`
       <ha-card header="AI Entity Renamer">
         <div class="card-content">
+          <div class="view-tabs">
+            <button
+              class="${this.view === 'entities' ? 'active' : ''}"
+              @click=${() => (this.view = 'entities')}
+            >
+              Entities
+            </button>
+            <button
+              class="${this.view === 'devices' ? 'active' : ''}"
+              @click=${() => (this.view = 'devices')}
+            >
+              Devices
+            </button>
+          </div>
           ${this.message ? html`
             <div class="message ${this.messageType}">
               ${this.message}
             </div>
           ` : ""}
 
+          ${this.view === 'entities' ? html`
           <div class="filters">
             <div class="search-box">
               <ha-icon icon="mdi:magnify"></ha-icon>
@@ -646,8 +663,7 @@ class EntityRenamerPanel extends LitElement {
                 </div>
               </div>
             ` : ""}
-            <hr />
-            <h2>Devices</h2>
+          ` : html`
             <div class="entity-table-container">
               <div class="select-all-row">
                 <input
@@ -823,6 +839,17 @@ class EntityRenamerPanel extends LitElement {
         background-color: #EBF8FF;
         color: #2C5282;
         border: 1px solid #BEE3F8;
+      }
+
+      .view-tabs {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 16px;
+      }
+
+      .view-tabs button.active {
+        background-color: var(--primary-color, #03a9f4);
+        color: var(--text-primary-color, #fff);
       }
 
       .filters {

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,8 @@
 # Development dependencies
 pytest>=7.0.0
 pytest-cov>=4.0.0
+pytest-asyncio>=0.21.0
+homeassistant>=2024.2.5
 flake8>=6.0.0
 black>=23.0.0
 isort>=5.12.0


### PR DESCRIPTION
## Summary
- add tabbed interface to switch between entity and device selectors
- document new tabs in README and changelog
- ignore local `.venv` directory
- include Home Assistant and pytest-asyncio in dev requirements for testing

## Testing
- `black .`
- `isort -v custom_components/entity_renamer/__init__.py`
- `pylint custom_components/entity_renamer`
- `pytest --cov=custom_components/entity_renamer --cov-report=xml` *(fails: AttributeError and missing registry data)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2d1e961483298a010a49ac1efd28